### PR TITLE
Add import map for Three.js modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,14 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/"
+        }
+      }
+    </script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="p-4 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Add import map in `index.html` to map `three` and `three/addons/` to CDN paths, resolving module resolution errors.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68931f8df998832baff5ed5b9eb248bb