### PR TITLE
Fix Three.js scene race by lazy initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@ const elementAssetMap = {
 // --- STATE MANAGEMENT ---
 let currentIndex = 0;
 let currentModel = null;
+let isSceneInitialized = false;
 
 // --- DOM ELEMENT REFERENCES (Refactored) ---
 const getEl = (id) => document.getElementById(id);
@@ -86,8 +87,17 @@ const loader = new GLTFLoader();
 
 // --- CORE FUNCTIONS ---
 function showView(viewName) {
-    view.home.classList.toggle('hidden', viewName !== 'home');
-    view.detail.classList.toggle('hidden', viewName !== 'detail');
+    if (viewName === 'detail') {
+        if (!isSceneInitialized) {
+            initScene();
+            isSceneInitialized = true;
+        }
+        view.home.classList.add('hidden');
+        view.detail.classList.remove('hidden');
+    } else {
+        view.detail.classList.add('hidden');
+        view.home.classList.remove('hidden');
+    }
 }
 
 function populateCreatureGrid(data = pokedexData) {
@@ -257,10 +267,8 @@ function initApp() {
     // Populate UI
     populateCreatureGrid();
     
-    // Initialize 3D Scene & Show Initial View
-    initScene();
-    displayCreature(0); // Display the first creature by default in the detail view's memory
-    showView('home'); // But show the home view first
+    // Show Initial View
+    showView('home');
 }
 
 initApp();


### PR DESCRIPTION
## Summary
- Add `isSceneInitialized` flag to track scene state
- Initialize Three.js scene only when detail view is first shown
- Remove eager scene setup and default creature display

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893403b0460832b9fd20b60a09fa472